### PR TITLE
Banner Iframe Display Patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.5]
+* Bug Fix: Fixed HTML escaping issue that prevented iframe banners from rendering correctly
+* Bug Fix: Resolved double banner display issue where banners appeared twice on themes supporting wp_body_open
+* Improvement: Enhanced banner HTML sanitization with custom method allowing iframes and banner-related HTML tags
+* Improvement: Implemented flag-based prevention system to ensure banners display only once
+* Code Quality: Replaced esc_js() with wp_json_encode() for proper HTML content handling in JavaScript
+* Theme Compatibility: Better fallback system for themes with and without wp_body_open support
+
 ## [1.5.4]
 * Bug Fix: Fixed translation loading timing issue by moving plugin initialization from `plugins_loaded` to `init` action
 * Internationalization: Ensures textdomain is loaded at priority 10 before plugin initializes at priority 20

--- a/includes/class-iwz-banner-container.php
+++ b/includes/class-iwz-banner-container.php
@@ -164,7 +164,7 @@ class IWZ_Banner_Container {
 	 * Display banner in header.
 	 */
 	public function display_header_banner() {
-		// Prevent double display
+		// Prevent double display.
 		if ( $this->header_banner_displayed ) {
 			return;
 		}
@@ -208,7 +208,7 @@ class IWZ_Banner_Container {
 	 * This outputs a script that runs after the DOM is loaded to insert the banner.
 	 */
 	public function display_header_banner_fallback() {
-		// Only use fallback if banner hasn't been displayed yet
+		// Only use fallback if banner hasn't been displayed yet.
 		if ( $this->header_banner_displayed ) {
 			return;
 		}
@@ -253,7 +253,7 @@ class IWZ_Banner_Container {
 	 * @param string $banner_html The banner HTML to insert.
 	 */
 	private function output_body_banner_script( $banner_html ) {
-		// Use JSON encoding to properly handle HTML content in JavaScript
+		// Use JSON encoding to properly handle HTML content in JavaScript.
 		$json_html = wp_json_encode( $banner_html );
 		echo '<script type="text/javascript">';
 		echo 'document.addEventListener("DOMContentLoaded", function() {';
@@ -528,56 +528,56 @@ class IWZ_Banner_Container {
 	private function sanitize_banner_html( $html ) {
 		$allowed_html = array(
 			'iframe' => array(
-				'src'             => array(),
-				'width'           => array(),
-				'height'          => array(),
-				'frameborder'     => array(),
-				'scrolling'       => array(),
-				'allow'           => array(),
-				'title'           => array(),
-				'style'           => array(),
-				'class'           => array(),
-				'id'              => array(),
-				'data-*'          => array(),
+				'src'         => array(),
+				'width'       => array(),
+				'height'      => array(),
+				'frameborder' => array(),
+				'scrolling'   => array(),
+				'allow'       => array(),
+				'title'       => array(),
+				'style'       => array(),
+				'class'       => array(),
+				'id'          => array(),
+				'data-*'      => array(),
 			),
 			'script' => array(
-				'src'             => array(),
-				'type'            => array(),
-				'class'           => array(),
-				'id'              => array(),
-				'async'           => array(),
-				'defer'           => array(),
+				'src'   => array(),
+				'type'  => array(),
+				'class' => array(),
+				'id'    => array(),
+				'async' => array(),
+				'defer' => array(),
 			),
 			'div'    => array(
-				'style'           => array(),
-				'class'           => array(),
-				'id'              => array(),
+				'style' => array(),
+				'class' => array(),
+				'id'    => array(),
 			),
 			'a'      => array(
-				'href'            => array(),
-				'target'          => array(),
-				'rel'             => array(),
-				'class'           => array(),
-				'id'              => array(),
+				'href'   => array(),
+				'target' => array(),
+				'rel'    => array(),
+				'class'  => array(),
+				'id'     => array(),
 			),
 			'img'    => array(
-				'src'             => array(),
-				'alt'             => array(),
-				'width'           => array(),
-				'height'          => array(),
-				'class'           => array(),
-				'id'              => array(),
-				'style'           => array(),
+				'src'    => array(),
+				'alt'    => array(),
+				'width'  => array(),
+				'height' => array(),
+				'class'  => array(),
+				'id'     => array(),
+				'style'  => array(),
 			),
 			'span'   => array(
-				'style'           => array(),
-				'class'           => array(),
-				'id'              => array(),
+				'style' => array(),
+				'class' => array(),
+				'id'    => array(),
 			),
 			'p'      => array(
-				'class'           => array(),
-				'id'              => array(),
-				'style'           => array(),
+				'class' => array(),
+				'id'    => array(),
+				'style' => array(),
 			),
 		);
 

--- a/includes/class-iwz-banner-container.php
+++ b/includes/class-iwz-banner-container.php
@@ -180,6 +180,7 @@ class IWZ_Banner_Container {
 		if ( empty( $banners ) ) {
 			$legacy_code = get_option( 'iwz_banner_wp_head_code', '' );
 			if ( ! empty( $legacy_code ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized via sanitize_banner_html method
 				echo $this->sanitize_banner_html( $legacy_code );
 				$this->header_banner_displayed = true;
 			}
@@ -198,6 +199,7 @@ class IWZ_Banner_Container {
 		}
 
 		if ( ! empty( $banner_output ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized via sanitize_banner_html method
 			echo $banner_output;
 			$this->header_banner_displayed = true;
 		}
@@ -258,6 +260,7 @@ class IWZ_Banner_Container {
 		echo '<script type="text/javascript">';
 		echo 'document.addEventListener("DOMContentLoaded", function() {';
 		echo 'var bannerDiv = document.createElement("div");';
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is JSON encoded and sanitized
 		echo 'bannerDiv.innerHTML = ' . $json_html . ';';
 		echo 'document.body.insertBefore(bannerDiv.firstChild, document.body.firstChild);';
 		echo '});';
@@ -279,6 +282,7 @@ class IWZ_Banner_Container {
 		if ( empty( $banners ) ) {
 			$legacy_code = get_option( 'iwz_banner_wp_footer_code', '' );
 			if ( ! empty( $legacy_code ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized via sanitize_banner_html method
 				echo $this->sanitize_banner_html( $legacy_code );
 			}
 			return;
@@ -289,6 +293,7 @@ class IWZ_Banner_Container {
 			if ( ! empty( $banner['enabled'] ) && ! empty( $banner['code'] ) ) {
 				$device_targeting = $banner['device_targeting'] ?? 'all';
 				if ( $this->should_display_for_device( $device_targeting ) ) {
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized via sanitize_banner_html method
 					echo $this->sanitize_banner_html( $banner['code'] );
 				}
 			}
@@ -437,6 +442,7 @@ class IWZ_Banner_Container {
 			// Check for legacy single banner.
 			$legacy_code = get_option( 'iwz_banner_get_sidebar_code', '' );
 			if ( ! empty( $legacy_code ) ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized via sanitize_banner_html method
 				echo $this->sanitize_banner_html( $legacy_code );
 			}
 			return;
@@ -453,6 +459,7 @@ class IWZ_Banner_Container {
 				continue;
 			}
 
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized via sanitize_banner_html method
 			echo $this->sanitize_banner_html( $banner['code'] );
 		}
 	}
@@ -515,6 +522,7 @@ class IWZ_Banner_Container {
 		$code_field    = 'iwz_banner_' . str_replace( '-', '_', sanitize_title( $location ) ) . '_code';
 
 		if ( get_option( $enabled_field ) ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized via sanitize_banner_html method
 			echo $this->sanitize_banner_html( get_option( $code_field, '' ) );
 		}
 	}

--- a/iwz-banner-container-plugin.php
+++ b/iwz-banner-container-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Banner Container Plugin
  * Plugin URI: https://imagewize.com/iwz-banner-container-plugin
  * Description: Add banners to different locations in your WordPress theme.
- * Version: 1.5.4
+ * Version: 1.5.5
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * License: GPL-2.0+
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // Define plugin constants.
-define( 'IWZ_BANNER_CONTAINER_VERSION', '1.5.4' );
+define( 'IWZ_BANNER_CONTAINER_VERSION', '1.5.5' );
 define( 'IWZ_BANNER_CONTAINER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IWZ_BANNER_CONTAINER_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
This pull request introduces version 1.5.5 of the IWZ Banner Container Plugin, focusing on bug fixes, improved sanitization, and better theme compatibility. Key updates include fixing banner rendering issues, enhancing HTML sanitization, and implementing a fallback system for themes without `wp_body_open` support.

### Bug Fixes:
* Fixed an HTML escaping issue that prevented iframe banners from rendering correctly.
* Resolved a double banner display issue where banners appeared twice on themes supporting `wp_body_open`.

### Improvements:
* Enhanced banner HTML sanitization with a new `sanitize_banner_html` method that allows specific tags like `iframe` and `script`.
* Introduced a fallback system for themes without `wp_body_open` support by adding a new `display_header_banner_fallback` method.

### Code Quality:
* Replaced `esc_js()` with `wp_json_encode()` for proper handling of HTML content in JavaScript.
* Consolidated sanitization logic across multiple banner display methods, replacing `wp_kses_post()` with the new `sanitize_banner_html` method. [[1]](diffhunk://#diff-72fff3e1b52362e1ba5bd788d69c4765fc1103259f5f6c8eec1315e766fb2fa4L200-R282) [[2]](diffhunk://#diff-72fff3e1b52362e1ba5bd788d69c4765fc1103259f5f6c8eec1315e766fb2fa4L358-R440) [[3]](diffhunk://#diff-72fff3e1b52362e1ba5bd788d69c4765fc1103259f5f6c8eec1315e766fb2fa4L401-R483)

### Theme Compatibility:
* Improved handling of banners for themes with and without `wp_body_open` by modifying `hook_banner_displays` to support both scenarios.

### Version Update:
* Updated the plugin version to 1.5.5 in `iwz-banner-container-plugin.php` and `CHANGELOG.md`. [[1]](diffhunk://#diff-3ff33ea11815f23c520fcf744daa2fc742d30e018c1ec5af95a741e5c2316bc1L6-R6) [[2]](diffhunk://#diff-3ff33ea11815f23c520fcf744daa2fc742d30e018c1ec5af95a741e5c2316bc1L21-R21) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R12)