### PR TITLE
Blabber Footer Banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.8.0]
+* New Feature: Added Blabber Footer Start banner location for displaying banners just above the footer element
+* New Feature: Blabber Footer Start targets `footer.footer_wrap` element and uses JavaScript-based insertion
+* Styling: Added specialized CSS for Blabber Footer Start banners with iframe height and width constraints
+* Styling: Implemented responsive design with max-width 100% for mobile compatibility
+* CSS Enhancement: Added high-specificity CSS rules to override Blabber theme's iframe styling conflicts
+* Multiple Banner Support: Full support for multiple banners with individual device targeting (desktop/mobile/all)
+* Admin Interface: Integrated into existing settings page with collapsible accordion interface
+* Documentation: Updated README and welcome page with new banner location information
+* Code Quality: Follows same patterns as existing Content Wrap banner location for consistency
+
 ## [1.7.0]
 * Breaking Change: Updated sidebar banner location to use `dynamic_sidebar_before` hook instead of `get_sidebar`
 * Improvement: Sidebar banners now display before any sidebar content (widgets) loads for better positioning

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The Banner Container Plugin allows you to easily add iframe codes to various loc
 - Before Sidebar Content - **NEW in v1.7.0**: Uses `dynamic_sidebar_before` hook to display banners before any sidebar widgets load, ensuring proper positioning above all sidebar content. Supports multiple banners and device targeting.
 - In Navigation Menu - with support for multiple banners and device targeting
 - Content Wrap (inside content wrapper elements) - **Blabber theme exclusive feature** that targets elements with the `content_wrapper` CSS class. This location uses JavaScript insertion and is specifically designed for the Blabber theme structure.
+- Blabber Footer Start (Top of Footer Area) - **Blabber theme exclusive feature** that displays banners just above the footer element with class `footer_wrap`. This location uses JavaScript insertion and is specifically designed for the Blabber theme footer structure.
 
 ## Requirements
 
@@ -49,25 +50,36 @@ The Banner Container Plugin allows you to easily add iframe codes to various loc
 
 **Theme compatibility**: This change should work with any theme that properly implements WordPress sidebars using `dynamic_sidebar()`. Most modern themes support this.
 
-### What is the Content Wrap banner location and when should I use it?
+### What are the Blabber theme exclusive banner locations and when should I use them?
 
-The Content Wrap banner location is a specialized banner placement designed exclusively for the **Blabber theme**. This feature targets elements with the `content_wrapper` CSS class that is specific to the Blabber theme structure.
+The Banner Container Plugin includes two specialized banner placements designed exclusively for the **Blabber theme**:
 
-**Important Notes:**
-- **Blabber theme only**: This feature only works with the Blabber theme as it specifically targets the `content_wrapper` class
-- Uses JavaScript-based insertion with DOM-ready event handling for proper placement
-- Includes specialized CSS styling with iframe constraints (100px height, 640px width)
-- Responsive design with max-width 100% for mobile compatibility
-- High-specificity CSS rules to override Blabber theme's iframe styling (`blabber_resize`, `trx_addons_resize` classes)
+#### Content Wrap Banner Location
+This feature targets elements with the `content_wrapper` CSS class that is specific to the Blabber theme structure.
 
 **When to use:**
 - You are using the Blabber theme
 - You want banners to appear inside the main content wrapper area
 - You need precise control over banner sizing within the Blabber theme's content structure
 
+#### Blabber Footer Start Banner Location
+This feature targets the footer element with class `footer_wrap` and displays banners just above the footer element.
+
+**When to use:**
+- You are using the Blabber theme
+- You want banners to appear just above the footer section
+- You need banner placement specifically positioned before the Blabber theme's footer structure
+
+**Important Notes for both locations:**
+- **Blabber theme only**: These features only work with the Blabber theme as they specifically target Blabber theme CSS classes
+- Use JavaScript-based insertion with DOM-ready event handling for proper placement
+- Include specialized CSS styling with iframe constraints (100px height, 640px width)
+- Responsive design with max-width 100% for mobile compatibility
+- High-specificity CSS rules to override Blabber theme's iframe styling (`blabber_resize`, `trx_addons_resize` classes)
+
 **When NOT to use:**
 - You are using any theme other than Blabber
-- Your theme doesn't have elements with the `content_wrapper` class
+- Your theme doesn't have elements with the required CSS classes (`content_wrapper` or `footer_wrap`)
 - In these cases, use other banner locations like Header, Footer, or Content instead
 
 ### Can I add banners to custom locations?

--- a/includes/class-iwz-banner-container-settings.php
+++ b/includes/class-iwz-banner-container-settings.php
@@ -84,6 +84,7 @@ class IWZ_Banner_Container_Settings {
 			'dynamic_sidebar_before' => __( 'Before Sidebar Content', 'banner-container-plugin' ),
 			'wp_nav_menu_items'      => __( 'In Navigation Menu', 'banner-container-plugin' ),
 			'content_wrap_inside'    => __( 'Inside Blabber Theme Content Wrap (Top of Content Area)', 'banner-container-plugin' ),
+			'blabber_footer_start'   => __( 'Blabber Footer Start (Just Above Footer Area)', 'banner-container-plugin' ),
 		);
 
 		// Allow theme/plugins to modify available locations.
@@ -131,8 +132,8 @@ class IWZ_Banner_Container_Settings {
 	public function register_settings() {
 		// Register a setting group for each location.
 		foreach ( $this->banner_locations as $location_key => $location_label ) {
-			// For head, footer, content, sidebar, navigation menu, and content_wrap_inside banners, use the new multiple banner system.
-			if ( in_array( $location_key, array( 'wp_head', 'wp_footer', 'the_content', 'dynamic_sidebar_before', 'wp_nav_menu_items', 'content_wrap_inside' ), true ) ) {
+			// For head, footer, content, sidebar, navigation menu, content_wrap_inside, and blabber_footer_start banners, use the new multiple banner system.
+			if ( in_array( $location_key, array( 'wp_head', 'wp_footer', 'the_content', 'dynamic_sidebar_before', 'wp_nav_menu_items', 'content_wrap_inside', 'blabber_footer_start' ), true ) ) {
 				// Register setting for enabled status.
 				register_setting(
 					'iwz_banner_container_settings',
@@ -395,7 +396,7 @@ class IWZ_Banner_Container_Settings {
 
 					// Get banner count for display in title.
 					$banner_count = 0;
-					if ( in_array( $location_key, array( 'wp_head', 'wp_footer', 'the_content', 'dynamic_sidebar_before', 'wp_nav_menu_items', 'content_wrap_inside' ), true ) ) {
+					if ( in_array( $location_key, array( 'wp_head', 'wp_footer', 'the_content', 'dynamic_sidebar_before', 'wp_nav_menu_items', 'content_wrap_inside', 'blabber_footer_start' ), true ) ) {
 						$banners      = get_option( 'iwz_banner_' . $location_key . '_banners', array() );
 						$banner_count = count(
 							array_filter(
@@ -1090,6 +1091,7 @@ class IWZ_Banner_Container_Settings {
 			updateLocationRemoveButtons('dynamic_sidebar_before');
 			updateLocationRemoveButtons('wp_nav_menu_items');
 			updateLocationRemoveButtons('content_wrap_inside');
+			updateLocationRemoveButtons('blabber_footer_start');
 		});
 		</script>
 		<?php

--- a/includes/class-iwz-banner-container-welcome.php
+++ b/includes/class-iwz-banner-container-welcome.php
@@ -132,6 +132,7 @@ class IWZ_Banner_Container_Welcome {
 					<li><?php esc_html_e( 'Before Sidebar Content (above all sidebar widgets)', 'banner-container-plugin' ); ?></li>
 					<li><?php esc_html_e( 'In Navigation Menu', 'banner-container-plugin' ); ?></li>
 					<li><?php esc_html_e( 'Top Blabber Content Wrap', 'banner-container-plugin' ); ?></li>
+					<li><?php esc_html_e( 'Blabber Footer Start (Just Above Footer Area)', 'banner-container-plugin' ); ?></li>
 				</ul>
 			</div>
 		</div>

--- a/iwz-banner-container-plugin.php
+++ b/iwz-banner-container-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Banner Container Plugin
  * Plugin URI: https://imagewize.com/iwz-banner-container-plugin
  * Description: Add banners to different locations in your WordPress theme.
- * Version: 1.7.0
+ * Version: 1.8.0
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * License: GPL-2.0+
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // Define plugin constants.
-define( 'IWZ_BANNER_CONTAINER_VERSION', '1.7.0' );
+define( 'IWZ_BANNER_CONTAINER_VERSION', '1.8.0' );
 define( 'IWZ_BANNER_CONTAINER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IWZ_BANNER_CONTAINER_URL', plugin_dir_url( __FILE__ ) );
 

--- a/public/css/iwz-banner-container-public.css
+++ b/public/css/iwz-banner-container-public.css
@@ -8,3 +8,19 @@ iframe.blabber_resize.trx_addons_resize {
 	max-width: 100% !important;
 	margin-bottom: 1rem;
 }
+
+/* Styling for Blabber footer start banner location */
+.iwz-banner-container[data-location="blabber_footer"] {
+	margin-bottom: 1rem;
+	text-align: center;
+}
+
+.iwz-banner-container[data-location="blabber_footer"] iframe.blabber_resize.trx_addons_resize,
+.iwz-banner-container[data-location="blabber_footer"] .blabber_resize.trx_addons_resize,
+.iwz-banner-container[data-location="blabber_footer"] iframe {
+	height: 100px !important;
+	max-height: 100px !important;
+	width: 640px !important;
+	max-width: 100% !important;
+	margin-bottom: 1rem;
+}


### PR DESCRIPTION
This pull request introduces a new banner location, "Blabber Footer Start," specifically for the Blabber theme. It allows banners to be displayed just above the footer area with support for multiple banners, device targeting, and responsive design. The update also includes styling, documentation, and code changes to integrate this feature seamlessly into the plugin.

### Feature Addition: Blabber Footer Start Banner Location
* Added a new banner location, `blabber_footer_start`, to display banners just above the footer in the Blabber theme. This includes JavaScript-based insertion and support for multiple banners with device targeting. ([1](#diff-72fff3e1b52362e1ba5bd788d69c4765fc1103259f5f6c8eec1315e766fb2fa4R137-R139), [2](#diff-72fff3e1b52362e1ba5bd788d69c4765fc1103259f5f6c8eec1315e766fb2fa4R582-R644))
* Updated CSS to provide specialized styling for the new banner location, ensuring compatibility with Blabber theme iframe constraints and responsive design. ([public/css/iwz-banner-container-public.css](#diff-82cc86770c4b3284255e0b99e7bab0c8a096b3eacea3d51f5fa30a1f679311dbR11-R26))
* Registered the new banner location in the plugin settings and admin interface, allowing users to enable, configure, and manage banners for this location. ([1](#diff-2fdc073ead1bda2559edd4f24f01a75442673bbb91c1a11d08e6a3dda5b4560cR87), [2](#diff-2fdc073ead1bda2559edd4f24f01a75442673bbb91c1a11d08e6a3dda5b4560cL134-R136), [3](#diff-2fdc073ead1bda2559edd4f24f01a75442673bbb91c1a11d08e6a3dda5b4560cL398-R399), [4](#diff-2fdc073ead1bda2559edd4f24f01a75442673bbb91c1a11d08e6a3dda5b4560cR1094))

### Documentation Updates
* Updated the `README.md` to include details about the new "Blabber Footer Start" banner location, its purpose, and usage guidelines. ([1](#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15), [2](#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R82))
* Added the new banner location to the plugin's welcome page for better visibility to users. ([includes/class-iwz-banner-container-welcome.php](#diff-0ec6cc4e726443b1ff9857b9cb22b35b4ccd1d104dd0b52e25674e4705edc576R135))

### Versioning and Changelog
* Bumped the plugin version to `1.8.0` and updated the `CHANGELOG.md` to reflect the addition of the new feature and related changes. ([1](#diff-3ff33ea11815f23c520fcf744daa2fc742d30e018c1ec5af95a741e5c2316bc1L6-R6), [2](#diff-3ff33ea11815f23c520fcf744daa2fc742d30e018c1ec5af95a741e5c2316bc1L21-R21), [3](#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R15))