### PR TITLE
Individual sticky footer banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.9.6]
+* Breaking Change: Removed global sticky footer banner option - sticky behavior is now controlled per individual banner
+* Enhancement: Each footer banner now has its own independent sticky setting for granular control
+* UI Improvement: Cleaner admin interface with sticky setting only available per banner, not globally
+* Backward Compatibility: Removed legacy global sticky setting registration and fallback logic
+* User Experience: Users can now mix sticky and non-sticky footer banners in the same location
+* Technical Enhancement: Simplified sticky footer logic by removing global setting dependencies
+
 ## [1.9.5]
 * UI Enhancement: Moved header and footer banner locations to the bottom of the settings page for better organization
 * Bug Fix: Fixed sticky footer banner option to properly toggle on/off

--- a/includes/class-iwz-banner-container-settings.php
+++ b/includes/class-iwz-banner-container-settings.php
@@ -179,19 +179,6 @@ class IWZ_Banner_Container_Settings {
 					);
 				}
 
-				// For footer banners only, add sticky setting.
-				if ( 'wp_footer' === $location_key ) {
-					register_setting(
-						'iwz_banner_container_settings',
-						'iwz_banner_wp_footer_sticky',
-						array(
-							'type'              => 'boolean',
-							'sanitize_callback' => 'rest_sanitize_boolean',
-							'default'           => false,
-						)
-					);
-				}
-
 				// Keep legacy settings for backward compatibility.
 				register_setting(
 					'iwz_banner_container_settings',
@@ -352,6 +339,11 @@ class IWZ_Banner_Container_Settings {
 			// Add alignment for head/footer banners.
 			if ( isset( $banner['alignment'] ) ) {
 				$sanitized_banner['alignment'] = sanitize_text_field( $banner['alignment'] );
+			}
+
+			// Add sticky setting for footer banners.
+			if ( isset( $banner['sticky'] ) ) {
+				$sanitized_banner['sticky'] = ! empty( $banner['sticky'] );
 			}
 
 			// Add content-specific fields if they exist.
@@ -755,29 +747,6 @@ class IWZ_Banner_Container_Settings {
 										</tr>
 										<?php endif; ?>
 										
-										<?php if ( 'wp_footer' === $location_key ) : ?>
-										<tr>
-											<th scope="row">
-												<label for="iwz_banner_wp_footer_sticky">
-													<?php esc_html_e( 'Sticky Footer Banner', 'banner-container-plugin' ); ?>
-												</label>
-											</th>
-											<td>
-												<input type="checkbox" 
-													id="iwz_banner_wp_footer_sticky" 
-													name="iwz_banner_wp_footer_sticky" 
-													value="1" 
-													<?php checked( 1, get_option( 'iwz_banner_wp_footer_sticky', false ) ); ?> />
-												<label for="iwz_banner_wp_footer_sticky">
-													<?php esc_html_e( 'Make footer banners stick to bottom of screen', 'banner-container-plugin' ); ?>
-												</label>
-												<p class="description">
-													<?php esc_html_e( 'When enabled, footer banners will remain fixed at the bottom of the viewport when scrolling.', 'banner-container-plugin' ); ?>
-												</p>
-											</td>
-										</tr>
-										<?php endif; ?>
-										
 										<tr>
 											<td colspan="2">
 												<?php if ( 'dynamic_sidebar_before' === $location_key ) : ?>
@@ -871,6 +840,28 @@ class IWZ_Banner_Container_Settings {
 																		</select>
 																		<p class="description">
 																			<?php esc_html_e( 'Choose the alignment for this banner.', 'banner-container-plugin' ); ?>
+																		</p>
+																	</td>
+																</tr>
+																<?php endif; ?>
+																<?php if ( 'wp_footer' === $location_key ) : ?>
+																<tr>
+																	<th scope="row">
+																		<label for="iwz_<?php echo esc_attr( $location_key ); ?>_banner_sticky_<?php echo esc_attr( $index ); ?>">
+																			<?php esc_html_e( 'Sticky Banner', 'banner-container-plugin' ); ?>
+																		</label>
+																	</th>
+																	<td>
+																		<input type="checkbox" 
+																			id="iwz_<?php echo esc_attr( $location_key ); ?>_banner_sticky_<?php echo esc_attr( $index ); ?>" 
+																			name="iwz_banner_<?php echo esc_attr( $location_key ); ?>_banners[<?php echo esc_attr( $index ); ?>][sticky]" 
+																			value="1" 
+																			<?php checked( ! empty( $banner['sticky'] ) ); ?> />
+																		<label for="iwz_<?php echo esc_attr( $location_key ); ?>_banner_sticky_<?php echo esc_attr( $index ); ?>">
+																			<?php esc_html_e( 'Make this banner stick to bottom of screen', 'banner-container-plugin' ); ?>
+																		</label>
+																		<p class="description">
+																			<?php esc_html_e( 'When enabled, this banner will remain fixed at the bottom of the viewport when scrolling.', 'banner-container-plugin' ); ?>
 																		</p>
 																	</td>
 																</tr>
@@ -1187,6 +1178,16 @@ class IWZ_Banner_Container_Settings {
 					'</tr>';
 				}
 				
+				var stickyField = '';
+				if (location === 'wp_footer') {
+					stickyField = '<tr>' +
+						'<th scope="row"><label for="iwz_' + location + '_banner_sticky_' + newIndex + '"><?php esc_html_e( 'Sticky Banner', 'banner-container-plugin' ); ?></label></th>' +
+						'<td><input type="checkbox" id="iwz_' + location + '_banner_sticky_' + newIndex + '" name="iwz_banner_' + location + '_banners[' + newIndex + '][sticky]" value="1" />' +
+						'<label for="iwz_' + location + '_banner_sticky_' + newIndex + '"><?php esc_html_e( 'Make this banner stick to bottom of screen', 'banner-container-plugin' ); ?></label>' +
+						'<p class="description"><?php esc_html_e( 'When enabled, this banner will remain fixed at the bottom of the viewport when scrolling.', 'banner-container-plugin' ); ?></p></td>' +
+					'</tr>';
+				}
+				
 				var newBannerHtml = '<div class="iwz-location-banner-item" data-index="' + newIndex + '" data-location="' + location + '">' +
 					'<div class="iwz-location-banner-header">' +
 						'<h4><?php esc_html_e( 'Banner', 'banner-container-plugin' ); ?> ' + (newIndex + 1) + '</h4>' +
@@ -1202,6 +1203,7 @@ class IWZ_Banner_Container_Settings {
 							'<td><textarea id="iwz_' + location + '_banner_code_' + newIndex + '" name="iwz_banner_' + location + '_banners[' + newIndex + '][code]" rows="6" class="large-text code"></textarea><p class="description"><?php esc_html_e( 'Enter the iframe or banner code to insert.', 'banner-container-plugin' ); ?></p></td>' +
 						'</tr>' +
 						alignmentField +
+						stickyField +
 						'<tr>' +
 							'<th scope="row"><label for="iwz_' + location + '_banner_device_' + newIndex + '"><?php esc_html_e( 'Device Targeting', 'banner-container-plugin' ); ?></label></th>' +
 							'<td><select id="iwz_' + location + '_banner_device_' + newIndex + '" name="iwz_banner_' + location + '_banners[' + newIndex + '][device_targeting]">' +

--- a/includes/class-iwz-banner-container.php
+++ b/includes/class-iwz-banner-container.php
@@ -297,8 +297,7 @@ class IWZ_Banner_Container {
 			return;
 		}
 
-		// Get global sticky and wrapper background color settings.
-		$sticky           = get_option( 'iwz_banner_wp_footer_sticky', false );
+		// Get global wrapper background color setting.
 		$wrapper_bg_color = get_option( 'iwz_banner_wp_footer_wrapper_bg_color', '#161515' );
 
 		// Get multiple banners.
@@ -308,8 +307,8 @@ class IWZ_Banner_Container {
 		if ( empty( $banners ) ) {
 			$legacy_code = get_option( 'iwz_banner_wp_footer_code', '' );
 			if ( ! empty( $legacy_code ) ) {
-				$alignment      = get_option( 'iwz_banner_wp_footer_alignment', 'left' );
-				$wrapped_banner = $this->wrap_banner_html( $this->sanitize_banner_html( $legacy_code ), '', 'wp_footer', $alignment, $sticky, $wrapper_bg_color );
+				$alignment = get_option( 'iwz_banner_wp_footer_alignment', 'left' );
+				$wrapped_banner = $this->wrap_banner_html( $this->sanitize_banner_html( $legacy_code ), '', 'wp_footer', $alignment, false, $wrapper_bg_color );
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized via sanitize_banner_html method
 				echo $wrapped_banner;
 			}
@@ -322,11 +321,15 @@ class IWZ_Banner_Container {
 				$device_targeting = $banner['device_targeting'] ?? 'all';
 				if ( $this->should_display_for_device( $device_targeting ) ) {
 					// Use individual banner alignment if set, otherwise use global default.
-					$alignment      = $banner['alignment'] ?? get_option( 'iwz_banner_wp_footer_alignment', 'left' );
+					$alignment = $banner['alignment'] ?? get_option( 'iwz_banner_wp_footer_alignment', 'left' );
+					// Use ONLY individual banner sticky setting.
+					$sticky = isset( $banner['sticky'] ) ? $banner['sticky'] : false;
 					$wrapped_banner = $this->wrap_banner_html( $this->sanitize_banner_html( $banner['code'] ), $banner['wrapper_class'] ?? '', 'wp_footer', $alignment, $sticky, $wrapper_bg_color );
 					// Add debug comment when sticky is enabled.
 					if ( $sticky ) {
-						echo '<!-- DEBUG: Footer banner with sticky enabled -->';
+						echo '<!-- DEBUG: Footer banner with individual sticky enabled -->';
+					} else {
+						echo '<!-- DEBUG: Footer banner with individual sticky disabled -->';
 					}
 					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized via sanitize_banner_html method and wrapped
 					echo $wrapped_banner;

--- a/includes/class-iwz-banner-container.php
+++ b/includes/class-iwz-banner-container.php
@@ -307,7 +307,7 @@ class IWZ_Banner_Container {
 		if ( empty( $banners ) ) {
 			$legacy_code = get_option( 'iwz_banner_wp_footer_code', '' );
 			if ( ! empty( $legacy_code ) ) {
-				$alignment = get_option( 'iwz_banner_wp_footer_alignment', 'left' );
+				$alignment      = get_option( 'iwz_banner_wp_footer_alignment', 'left' );
 				$wrapped_banner = $this->wrap_banner_html( $this->sanitize_banner_html( $legacy_code ), '', 'wp_footer', $alignment, false, $wrapper_bg_color );
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content is sanitized via sanitize_banner_html method
 				echo $wrapped_banner;
@@ -323,7 +323,7 @@ class IWZ_Banner_Container {
 					// Use individual banner alignment if set, otherwise use global default.
 					$alignment = $banner['alignment'] ?? get_option( 'iwz_banner_wp_footer_alignment', 'left' );
 					// Use ONLY individual banner sticky setting.
-					$sticky = isset( $banner['sticky'] ) ? $banner['sticky'] : false;
+					$sticky         = isset( $banner['sticky'] ) ? $banner['sticky'] : false;
 					$wrapped_banner = $this->wrap_banner_html( $this->sanitize_banner_html( $banner['code'] ), $banner['wrapper_class'] ?? '', 'wp_footer', $alignment, $sticky, $wrapper_bg_color );
 					// Add debug comment when sticky is enabled.
 					if ( $sticky ) {

--- a/iwz-banner-container-plugin.php
+++ b/iwz-banner-container-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: Banner Container Plugin
  * Plugin URI: https://imagewize.com/iwz-banner-container-plugin
  * Description: Add banners to different locations in your WordPress theme.
- * Version: 1.9.5
+ * Version: 1.9.6
  * Author: Jasper Frumau
  * Author URI: https://imagewize.com
  * License: GPL-2.0+
@@ -18,7 +18,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 // Define plugin constants.
-define( 'IWZ_BANNER_CONTAINER_VERSION', '1.9.5' );
+define( 'IWZ_BANNER_CONTAINER_VERSION', '1.9.6' );
 define( 'IWZ_BANNER_CONTAINER_PATH', plugin_dir_path( __FILE__ ) );
 define( 'IWZ_BANNER_CONTAINER_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
This pull request introduces a breaking change to the sticky footer banner functionality in the `iwz-banner-container-plugin`, transitioning from a global sticky setting to individual banner-level control. It also includes enhancements to the user interface, backward compatibility adjustments, and updates to the plugin's version.

### Breaking Changes:
* Removed the global sticky footer banner setting and replaced it with individual sticky settings for each footer banner, allowing more granular control. (`CHANGELOG.md` - [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R12) `class-iwz-banner-container-settings.php` - [[2]](diffhunk://#diff-2fdc073ead1bda2559edd4f24f01a75442673bbb91c1a11d08e6a3dda5b4560cL182-L194) [[3]](diffhunk://#diff-72fff3e1b52362e1ba5bd788d69c4765fc1103259f5f6c8eec1315e766fb2fa4L300-R300)

### Enhancements:
* Added a new "sticky" checkbox for each footer banner in the admin interface, enabling users to toggle the sticky behavior for individual banners. (`class-iwz-banner-container-settings.php` - [[1]](diffhunk://#diff-2fdc073ead1bda2559edd4f24f01a75442673bbb91c1a11d08e6a3dda5b4560cR847-R868) [[2]](diffhunk://#diff-2fdc073ead1bda2559edd4f24f01a75442673bbb91c1a11d08e6a3dda5b4560cR1206)
* Updated the `sanitize_location_banners` function to handle the new individual sticky setting. (`class-iwz-banner-container-settings.php` - [includes/class-iwz-banner-container-settings.phpR344-R348](diffhunk://#diff-2fdc073ead1bda2559edd4f24f01a75442673bbb91c1a11d08e6a3dda5b4560cR344-R348))
* Improved debug logging to indicate whether individual sticky settings are enabled or disabled for each banner. (`class-iwz-banner-container.php` - [includes/class-iwz-banner-container.phpR325-R332](diffhunk://#diff-72fff3e1b52362e1ba5bd788d69c4765fc1103259f5f6c8eec1315e766fb2fa4R325-R332))

### Technical Adjustments:
* Refactored the `display_footer_banner` function to remove dependencies on the global sticky setting and use only the individual banner sticky settings. (`class-iwz-banner-container.php` - [[1]](diffhunk://#diff-72fff3e1b52362e1ba5bd788d69c4765fc1103259f5f6c8eec1315e766fb2fa4L312-R311) [[2]](diffhunk://#diff-72fff3e1b52362e1ba5bd788d69c4765fc1103259f5f6c8eec1315e766fb2fa4R325-R332)
* Updated plugin version to `1.9.6` and documented the changes in the `CHANGELOG.md` file. (`iwz-banner-container-plugin.php` - [[1]](diffhunk://#diff-3ff33ea11815f23c520fcf744daa2fc742d30e018c1ec5af95a741e5c2316bc1L6-R6) [[2]](diffhunk://#diff-3ff33ea11815f23c520fcf744daa2fc742d30e018c1ec5af95a741e5c2316bc1L21-R21) `CHANGELOG.md` - [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R12)